### PR TITLE
add check for all items to be stopped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,7 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+
+# ionide vscode
+
+.ionide/

--- a/SyncEngine.Tests/_Sync.fs
+++ b/SyncEngine.Tests/_Sync.fs
@@ -90,9 +90,12 @@ let ``Stopping engine sets state to stopped`` () =
         do! engines.Stop()
 
         // Verify
-        engines.TryFind(syncItem1.Id)
-        |> function
-           | None   -> failwith "Failed to find sync item"
-           | Some (v:SyncItem<int,string>) -> v.State |> should equal Started
+        let stopped = engines.CheckAllEnginesItemsStopped()
+        stopped |> should equal false
+
+        // engines.TryFind(syncItem1.Id)
+        // |> function
+        //    | None   -> failwith "Failed to find sync item"
+        //    | Some (v:SyncItem<int,string>) -> v.State |> should equal Started
 
     } |> Async.RunSynchronously

--- a/SyncEngine/SyncEngine.fs
+++ b/SyncEngine/SyncEngine.fs
@@ -9,8 +9,9 @@ type IEngine =
     abstract member Start : unit -> unit
     abstract member Stop  : unit -> unit
     abstract member Stop  : Id   -> unit
+    abstract member AllItemsStopped: bool with get
 
-type Engine<'submission,'response>(syncItems:SyncItem<'submission,'response> seq) =
+type Engine<'submission,'response>(syncItems : SyncItem<'submission,'response> seq) =
 
     let mutable errors = seq []
     let mutable state  = ""
@@ -55,6 +56,15 @@ type Engine<'submission,'response>(syncItems:SyncItem<'submission,'response> seq
 
     interface IEngine with
 
+        member this.AllItemsStopped with get() =
+            syncItems 
+            |> Seq.forall(fun item -> item.State = Stopped)
+
+        member this.AllItemsStarted with get() =
+            syncItems 
+            |> Seq.forall(fun item -> item.State = Started)
+
+
         member x.Start() : unit =
 
             let execute (sync:SyncItem<_,_>) = 
@@ -81,8 +91,11 @@ type MultiEngine(engines:IEngine seq) =
 
     member x.Start() = engines |> Seq.iter(fun engine -> engine.Start())
     member x.Stop()  = async { engines |> Seq.iter(fun engine -> engine.Stop()) }
+    member x.CheckAllEnginesItemsStopped() =
+        engines |> Seq.forall (fun engine -> engine.AllItemsStopped)
 
-    member x.TryFind(id:Id) =
 
-        None
-        //engines |> Seq.tryFind (fun v -> v.SyncItems |> Seq.tryFind())
+    // member x.TryFind(id:Id) =
+
+    //     None
+    //     //engines |> Seq.tryFind (fun v -> v.SyncItems |> Seq.tryFind())


### PR DESCRIPTION
I tried few approaches but I faced (I guess) the same issues about the generic typings and since you weren't around to ask anymore I checked that the test tried to assert that any of the items in the engine was still as "started" so I thought perhaps A more general solution like an "AllStarted" or "AllStopped" would achieve the same goal

also naming is hard and I left your code commented out, feel free to close this one if it doesn't fit what you had in mind
cheers!